### PR TITLE
Fix `Infoevent` sensor

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -232,8 +232,6 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         key="113",  # 0x0071
         name="Infoevent",
         icon="mdi:eye",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
`device_class` and `state_class` are not applicable for this sensor