### PR TITLE
Read multiple values in chunks of max 8 values

### DIFF
--- a/custom_components/kamstrup_403/pykamstrup/kamstrup.py
+++ b/custom_components/kamstrup_403/pykamstrup/kamstrup.py
@@ -15,6 +15,7 @@ import serial
 from .const import ESCAPES, UNITS
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+MULTIPLE_NBR_MAX: int = 8
 
 
 class Kamstrup:
@@ -158,6 +159,14 @@ class Kamstrup:
         self, multiple_nbr: list[int]
     ) -> (tuple[None, None] | tuple[float | None, str | None] | dict):
         """Get values from the meter"""
+
+        if len(multiple_nbr) > MULTIPLE_NBR_MAX:
+            multiple_nbr = multiple_nbr[:MULTIPLE_NBR_MAX]
+            _LOGGER.warning(
+                "Can only get %i values at once, will only update %s",
+                MULTIPLE_NBR_MAX,
+                multiple_nbr,
+            )
 
         # Construct the request.
         req = bytearray()


### PR DESCRIPTION
I've enabled 10 sensors, see below the log output:

Log:
```
2023-01-28 15:45:58.213 DEBUG (MainThread) [custom_components.kamstrup_403] Set up entry, with scan_interval of 600 seconds and timeout of 0.5 seconds
2023-01-28 15:46:01.498 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 60
2023-01-28 15:46:01.499 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 86
2023-01-28 15:46:01.499 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 87
2023-01-28 15:46:01.499 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 68
2023-01-28 15:46:01.500 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 149
2023-01-28 15:46:01.500 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 150
2023-01-28 15:46:01.501 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 146
2023-01-28 15:46:01.501 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 147
2023-01-28 15:46:01.501 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 113
2023-01-28 15:46:01.501 DEBUG (MainThread) [custom_components.kamstrup_403] Register command 1004
2023-01-28 15:46:01.743 DEBUG (MainThread) [custom_components.kamstrup_403] Start update
2023-01-28 15:46:01.743 DEBUG (MainThread) [custom_components.kamstrup_403] Get values for [60, 86, 87, 68, 149, 150, 146, 147]
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 60, value: 35.657000000000004 GJ
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 86, value: 38.61 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 87, value: 33.77 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 68, value: 259.912 m³
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 149, value: 77.0 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 150, value: 43.0 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 146, value: 77.0 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 147, value: 43.0 °C
2023-01-28 15:46:02.529 DEBUG (MainThread) [custom_components.kamstrup_403] Get values for [113, 1004]
2023-01-28 15:46:02.850 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 113, value: 0.0 
2023-01-28 15:46:02.850 DEBUG (MainThread) [custom_components.kamstrup_403] New value for sensor 1004, value: 17725.0 h
2023-01-28 15:46:02.850 DEBUG (MainThread) [custom_components.kamstrup_403] Finished update, 0 out of 10 readings failed
2023-01-28 15:46:02.850 DEBUG (MainThread) [custom_components.kamstrup_403] Finished fetching kamstrup_403 data in 1.108 seconds (success: True)
```