### PR TITLE
Some quick corrections

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -144,7 +144,6 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         key="126",  # 0x007E
         name="MinFlow_Y",
         icon="mdi:water",
-        device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
@@ -152,7 +151,6 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         key="124",  # 0x0096
         name="MaxFlow_Y",
         icon="mdi:water",
-        device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),

--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -228,7 +228,7 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
     ),
     SensorEntityDescription(
         key="113",  # 0x0071
-        name="Infoevent",
+        name="Info-event_counter",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),


### PR DESCRIPTION
Issue: Entity sensor.kamstrup_403_minflow_y (<class 'custom_components.kamstrup_403.sensor.KamstrupMeterSensor'>) is using native unit of measurement 'l/h' which is not a valid unit for the device class ('temperature') it is using; expected one of ['K', '°F', '°C']; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author. Same goes for sensor.kamstrup_403_maxflow_y.

To prevent mix up with the event status of the meter I renamed the Entity to Info-event_counter. This entity represents the number of times the info code has been changed. The value is increased every time the info code is changed. The actual Info-event has to be found, I guess it could be 112 but still to be determined.