### PR TITLE
Added precision to Infoevent and Infoevent Counter

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -184,12 +184,16 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         name="Infoevent",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     SensorEntityDescription(
         key="113",  # 0x0071
         name="Infoevent counter",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     SensorEntityDescription(
         key="1001",  # 0x03E9


### PR DESCRIPTION
Both Infoevent and Infoevent counter are integers. Therefor added stateclass:measurement. This brings up the display_precision option where 0 is displayed as 0,0 - to prevent this default to suggested display precision = 0