### PR TITLE
Added precision to event, eventcounter and serialnumber

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -200,6 +200,8 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         name="Serial number",
         icon="mdi:barcode",
         entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     SensorEntityDescription(
         key="1004",  # 0x03EC

--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -184,12 +184,16 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         name="Infoevent",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     SensorEntityDescription(
         key="113",  # 0x0071
         name="Infoevent counter",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
     SensorEntityDescription(
         key="1001",  # 0x03E9


### PR DESCRIPTION
All Serialnumber, Infoevent and Infoevent values are integers. Therefor added stateclass:measurement. This brings up the display_precision option where 0 is displayed as 0,0 - to prevent this default to suggested display precision = 0