### PR TITLE
Fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,12 @@ testpaths = ["tests"]
 norecursedirs = ".git"
 addopts = "--strict-markers --cov=custom_components"
 asyncio_mode = "auto"
+filterwarnings = [
+    "error",
+    "ignore::UserWarning",
+    # note the use of single quote below to denote "raw" strings in TOML
+    'ignore:function ham\(\) is deprecated:DeprecationWarning',
+]
 
 [tool.isort]
 # https://github.com/PyCQA/isort/wiki/isort-Settings

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,6 +19,7 @@ from .const import MOCK_CONFIG
 # Home Assistant using the pytest_homeassistant_custom_component plugin.
 # Assertions allow you to verify that the return value of whatever is on the left
 # side of the assertion matches with the right side.
+@pytest.fixture
 async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
@@ -29,18 +30,23 @@ async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     # call, no code from custom_components/kamstrup_403/api.py actually runs. TODO. search for api
     assert await async_setup_entry(hass, config_entry)
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert type(hass.data[DOMAIN][config_entry.entry_id]) == KamstrupUpdateCoordinator
+    assert isinstance(
+        hass.data[DOMAIN][config_entry.entry_id], KamstrupUpdateCoordinator
+    )
 
     # Reload the entry and assert that the data from above is still there
     assert await async_reload_entry(hass, config_entry) is None
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert type(hass.data[DOMAIN][config_entry.entry_id]) == KamstrupUpdateCoordinator
+    assert isinstance(
+        hass.data[DOMAIN][config_entry.entry_id], KamstrupUpdateCoordinator
+    )
 
     # Unload the entry and verify that the data has been removed
     assert await async_unload_entry(hass, config_entry)
     assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
+@pytest.fixture
 async def test_setup_entry_exception(hass, error_on_get_data):
     """Test ConfigEntryNotReady when API raises an exception during entry setup."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,9 @@
 """Tests sensor."""
-
 from datetime import datetime
 
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.util import dt
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kamstrup_403 import async_setup_entry
@@ -17,6 +17,7 @@ from custom_components.kamstrup_403.sensor import (
 from .const import MOCK_CONFIG
 
 
+@pytest.fixture
 async def test_kamstrup_gas_sensor(hass, bypass_get_data):
     """Test for gas sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
@@ -37,6 +38,7 @@ async def test_kamstrup_gas_sensor(hass, bypass_get_data):
     assert sensor.state == 1234
 
 
+@pytest.fixture
 async def test_kamstrup_meter_sensor(hass, bypass_get_data):
     """Test for base sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
@@ -59,6 +61,7 @@ async def test_kamstrup_meter_sensor(hass, bypass_get_data):
     assert sensor.native_unit_of_measurement == "GJ"
 
 
+@pytest.fixture
 async def test_kamstrup_date_sensor(hass, bypass_get_data):
     """Test for date sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")


### PR DESCRIPTION
Use fixures
Fix: PytestDeprecationWarning: The hookimpl CovPlugin.pytest_testnodedown uses old-style configuration options