### PR TITLE
Added cooling energy (E3) support

### DIFF
--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -30,6 +30,14 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
+        key="63",  # 0x003F
+        name="Cooling Energy (E3)",
+        icon="mdi:snowflake",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+    SensorEntityDescription(
         key="80",  # 0x0050
         name="Power",
         icon="mdi:flash",


### PR DESCRIPTION
My house has floor heating and also floor cooling and thus my meter which is a Kamstrup 403 has two meters, the usual E1 meter and also E3 for cooling energy. I have found the command for E3 and added it. I have been tested this code on my own meter and the readings are correct (the same as on the display). 

I have disabled the sensor by default to preserve battery and because not all users will have the E3 meter.

I found it hard to find the codes/commands, so in case it might be useful to someone:
[documentation](https://www.askom.pl/WebHelp/Asix_Evo_10/EN/Communication_Drivers_HTML5/index.htm#t=Kmp.htm)
[Github Gist](https://gist.github.com/noahlvb/0e1ca7caaf1b236b3bdf27ee4019afe2)
The document is for a different meter but the Kamstrup protocol is mostly the same across devices and most codes lie up.