### PR TITLE
Add extra port open, and add ser2net example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ custom_components/kamstrup_403/sensor.py
 ## Configuration
 
 Configuration is done in the UI. It's recommended to use devices as `/dev/serial/by-id` and not `/dev/ttyUSB1` as the port. This is because the first example is a stable identifier, while the second can change when USB devices are added or removed, or even when you perform a system reboot.<br>
-The port should look like this: `/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D307PBVY-if00-port0`.
+The port should look like this: `/dev/serial/by-id/usb-FTDI_FT230X_Basic_UART_D307PBVY-if00-port0`. If the port is a remote port (e.g. by using ser2net) it's possible to use a socket connection too, by using something similar to `socket://192.168.1.101:20019`.
 
 Some meters contain a battery, and communicating with the meter does impact battery life. By default, this component updates every `3600` seconds (1 hour). This is configurable. Also, since version `2.0.1` you can also configure the serial timeout. The default value is `1.0` seconds, if you get the error `Finished update, No readings from the meter. Please check the IR connection` you can try to increase this value. Fractional numbers are allowed (eg. `0.5`).
 You can do this by pressing `configure` on the Integrations page:

--- a/custom_components/kamstrup_403/pykamstrup/kamstrup.py
+++ b/custom_components/kamstrup_403/pykamstrup/kamstrup.py
@@ -48,14 +48,20 @@ class Kamstrup:
             log += f" {byte:02x}"
         _LOGGER.debug(log)
 
+    def _make_sure_port_is_opened(self):
+        if not self.ser.is_open:
+            self.ser.open()
+
     def _write(self, data: tuple[int]):
         """Write directly to the meter"""
+        self._make_sure_port_is_opened()
         bytearray_data = bytearray(data)
         self._debug("Write", bytearray_data)
         self.ser.write(bytearray_data)
 
     def _read(self) -> int | None:
         """Read directly from the meter"""
+        self._make_sure_port_is_opened()
         data = self.ser.read(1)
         if len(data) == 0:
             _LOGGER.debug("Rx Timeout")


### PR DESCRIPTION
I'm using this component combined with ser2net. This allows me to have a simple device with a USB port in the utility closet, and have my HA instance running somewhere else in the network.

Since using ser2net is less reliable, and TCP connections sometimes drop, this PR repairs that connection.