### PR TITLE
chore(deps): migrate from pyserial-asyncio-fast to serialx

### DIFF
--- a/custom_components/kamstrup_403/coordinator.py
+++ b/custom_components/kamstrup_403/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from serial import SerialException
+from serialx import SerialException
 
 from .const import DOMAIN
 from .pykamstrup.kamstrup import MULTIPLE_NBR_MAX, Kamstrup

--- a/custom_components/kamstrup_403/manifest.json
+++ b/custom_components/kamstrup_403/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/golles/ha-kamstrup_403/issues",
   "loggers": ["custom_components.kamstrup_403"],
-  "requirements": ["pyserial-asyncio-fast==0.16"],
+  "requirements": ["serialx==1.7.2"],
   "version": "0.0.1"
 }

--- a/custom_components/kamstrup_403/pykamstrup/kamstrup.py
+++ b/custom_components/kamstrup_403/pykamstrup/kamstrup.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import math
 
-import serial_asyncio_fast as serial_asyncio
+import serialx
 
 from .const import ESCAPES, UNITS
 
@@ -36,7 +36,7 @@ class Kamstrup:
     async def connect(self) -> None:
         """Connect to the serial device."""
         if self.reader is None or self.writer is None:
-            self.reader, self.writer = await serial_asyncio.open_serial_connection(url=self.url, baudrate=self.baudrate)
+            self.reader, self.writer = await serialx.open_serial_connection(url=self.url, baudrate=self.baudrate)
 
     async def disconnect(self) -> None:
         """Disconnect from the serial device."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "homeassistant>=2026.2.0",
-    "pyserial-asyncio-fast==0.16",
+    "serialx==1.7.2",
 ]
 
 Documentation = "https://github.com/golles/ha-kamstrup_403"

--- a/tests/pykamstrup/test_kamstrup.py
+++ b/tests/pykamstrup/test_kamstrup.py
@@ -35,8 +35,7 @@ def test_crc_1021() -> None:
 
 def test_debug(caplog: pytest.LogCaptureFixture) -> None:
     """Test debug logging."""
-    with patch("serial.serial_for_url"):
-        kamstrup = Kamstrup("test_url", 9600, 1.0)
+    kamstrup = Kamstrup("test_url", 9600, 1.0)
 
     with caplog.at_level("DEBUG"):
         kamstrup._debug("Test message", bytearray([0x01, 0x02, 0xFF]))  # pylint: disable=protected-access
@@ -46,7 +45,7 @@ def test_debug(caplog: pytest.LogCaptureFixture) -> None:
 
 async def test_connect() -> None:
     """Test connection method."""
-    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serial_asyncio.open_serial_connection") as mock_open:
+    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serialx.open_serial_connection") as mock_open:
         mock_reader = AsyncMock()
         mock_writer = AsyncMock()
         mock_open.return_value = (mock_reader, mock_writer)
@@ -61,7 +60,7 @@ async def test_connect() -> None:
 
 async def test_connect_already_connected() -> None:
     """Test connection when already connected."""
-    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serial_asyncio.open_serial_connection") as mock_open:
+    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serialx.open_serial_connection") as mock_open:
         mock_reader = AsyncMock()
         mock_writer = AsyncMock()
         mock_open.return_value = (mock_reader, mock_writer)
@@ -131,7 +130,7 @@ async def test_write_no_writer() -> None:
 
 async def test_ensure_connected_missing_reader() -> None:
     """Test _ensure_connected when reader is None."""
-    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serial_asyncio.open_serial_connection") as mock_open:
+    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serialx.open_serial_connection") as mock_open:
         mock_reader = AsyncMock()
         mock_writer = AsyncMock()
         mock_open.return_value = (mock_reader, mock_writer)
@@ -149,7 +148,7 @@ async def test_ensure_connected_missing_reader() -> None:
 
 async def test_ensure_connected_missing_writer() -> None:
     """Test _ensure_connected when writer is None."""
-    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serial_asyncio.open_serial_connection") as mock_open:
+    with patch("custom_components.kamstrup_403.pykamstrup.kamstrup.serialx.open_serial_connection") as mock_open:
         mock_reader = AsyncMock()
         mock_writer = AsyncMock()
         mock_open.return_value = (mock_reader, mock_writer)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from serial import SerialException
+from serialx import SerialException
 
 from custom_components.kamstrup_403.const import DOMAIN
 from custom_components.kamstrup_403.coordinator import KamstrupUpdateCoordinator

--- a/uv.lock
+++ b/uv.lock
@@ -941,7 +941,7 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },
-    { name = "pyserial-asyncio-fast" },
+    { name = "serialx" },
 ]
 
 [package.dev-dependencies]
@@ -969,7 +969,7 @@ runhass = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.2.0" },
-    { name = "pyserial-asyncio-fast", specifier = "==0.16" },
+    { name = "serialx", specifier = "==1.7.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -2000,27 +2000,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c7bfc0aa516016c46dc4c0f380ffccbd742a61af1eda/PyRIC-0.1.6.3.tar.gz", hash = "sha256:b539b01cafebd2406c00097f94525ea0f8ecd1dd92f7731f43eac0ef16c2ccc9", size = 870401, upload-time = "2016-12-04T07:54:48.374Z" }
 
 [[package]]
-name = "pyserial"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
-]
-
-[[package]]
-name = "pyserial-asyncio-fast"
-version = "0.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyserial" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/d1/6c444e0f6b886345a7993d358c6734ccc440521cdca4999601e86f111708/pyserial_asyncio_fast-0.16.tar.gz", hash = "sha256:fd52643380406739d777014b0aea0873d756b542eb62f7556567239cec007115", size = 32696, upload-time = "2025-03-27T02:35:20.624Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/19/f76987bad313bb2dabf21914c1ec7441a1e846f05764f9948f1ccc2640a8/pyserial_asyncio_fast-0.16-py3-none-any.whl", hash = "sha256:88939d94e341a04c0c8bc3c1ed4e874439cb5a1e21ccfb0fd7315a8e45df1687", size = 9729, upload-time = "2025-03-27T02:35:19.062Z" },
-]
-
-[[package]]
 name = "pyspeex-noise"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2266,6 +2245,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2430,6 +2419,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/69/f3d048692aac843f41102507f6257138392ec841c16718f0618d27051caf/sentence_stream-1.3.0.tar.gz", hash = "sha256:b06261d35729de97df9002a1cc708f9a888f662b80d5d6d008ee69c51f36041b", size = 10049, upload-time = "2026-01-08T16:25:06.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/b6/48339c109bab6f54ff608800773b9425464c6cbf7fd3f2ba01294d78be3d/sentence_stream-1.3.0-py3-none-any.whl", hash = "sha256:7448d131315b85eefdf238e5edd9caa62899acf609145d5e0e10c09812eb8a1d", size = 8707, upload-time = "2026-01-08T16:25:05.918Z" },
+]
+
+[[package]]
+name = "serialx"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/ad/bb2566ff39c10d4683a38cbdd78f79d891d2c7c6dfd5a73664db9cd77da6/serialx-1.7.2.tar.gz", hash = "sha256:29e3b7fae7bfa9253e5b299b847ebd9ed537357558eb3128eb4079a178a644dc", size = 565568, upload-time = "2026-05-06T20:48:14.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/61/64c18aa14229820b8561da82c28233ce3fae1fbd12672409d559e4f09c2b/serialx-1.7.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:96fbcc2244d889b912fe5c80a06693881c8c0ffd188df7d286f88b639764cacd", size = 281863, upload-time = "2026-05-06T20:48:06.254Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/79/39084430e47e40d0411a226d702f8811056fa24123a4a79d9c8c29fd560d/serialx-1.7.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7b9fb35b7a9a954a1f4c8793aae1cf710d558682063216884aa74a42be1361ec", size = 279410, upload-time = "2026-05-06T20:48:07.721Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/86/82355cdf34904f9c49e4e0a34df13f3feb5465714dd016ffe70f7b5c0505/serialx-1.7.2-cp310-abi3-win32.whl", hash = "sha256:48543a67830740b32174fcaa8636a70744fe5f575c4cc7812262f5ac7c10cae2", size = 180891, upload-time = "2026-05-06T20:48:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4d/9951ab6f99d5537d9e5fcc0192f6ac422ee8a6073013dc667921715edefe/serialx-1.7.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd02aa8b4c293e8fba5268103e5bfd78767980f36faaba5d913877e482a8bc3", size = 186897, upload-time = "2026-05-06T20:48:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/49/73371735e7d4e9e32cb0dc11443df70de0cdd1f42b721b86f3a4f927db70/serialx-1.7.2-cp310-abi3-win_arm64.whl", hash = "sha256:717283d86c34ccac4faa782e6ab61d8c32645f1b0f7b01396c31e5e6b6df8118", size = 183202, upload-time = "2026-05-06T20:48:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/41/a8c19071bf60cbf6e0acff4dc3769cf2e705dd1e1a3d11438d82764f078e/serialx-1.7.2-py3-none-any.whl", hash = "sha256:0b5485a1a4b3e0b2f1f80fe84b7c40fb679d55265f7fb805912a7f52f6585e3d", size = 63406, upload-time = "2026-05-06T20:48:13.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
Replace pyserial-asyncio-fast==0.16 with serialx==1.7.2, which is a drop-in replacement unifying pyserial, pyserial-asyncio, and pyserial-asyncio-fast. Update imports, exception handling, and test patch paths accordingly.

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
