### PR TITLE
fix(deps): stop pinning serialx in manifest.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,6 +53,12 @@
       "enabled": false
     },
     {
+      "description": "Don't pin serialx in manifest.json — Home Assistant core ships it and rejects mismatched pins",
+      "matchFileNames": ["custom_components/**/manifest.json"],
+      "matchPackageNames": ["serialx"],
+      "enabled": false
+    },
+    {
       "description": "Python dependencies",
       "matchManagers": ["pep621"],
       "addLabels": ["python"]

--- a/custom_components/kamstrup_403/manifest.json
+++ b/custom_components/kamstrup_403/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/golles/ha-kamstrup_403/issues",
   "loggers": ["custom_components.kamstrup_403"],
-  "requirements": ["serialx==1.8.0"],
+  "requirements": ["serialx"],
   "version": "0.0.1"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
Home Assistant core ships its own serialx and rejects integrations that pin a mismatched version, so every HA or Renovate bump caused user-facing breakage. Let HA decide the version, and add a Renovate rule to keep manifest.json unpinned going forward. The pin remains in pyproject.toml so CI still catches API drift.

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
