### PR TITLE
add high resolution E1 Heat Energy register

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,13 @@ Next to that, the component will read up to 8 sensors in one interaction with th
 
 This component does support integration into the Home Assitant's gas energy dashboard.
 
-- Heat Energy (E1) - GJ
+- Heat Energy (E1) - GJ, or Heat Energy (E1) high res - Wh
 - Flow - L/h
+
+The high res sensor gives a much better insight into the spread of heating usage throughout the day.
+
+If you are upgrading, and you were using Heat Energy (E1), be careful with changing the entity.
+Just adding the new high res one and deleting the old one will make all your old data invisible.
 
 ### Gas conversion sensor
 

--- a/custom_components/kamstrup_403/sensor.py
+++ b/custom_components/kamstrup_403/sensor.py
@@ -25,6 +25,13 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
+        key="266",  # 0x010A
+        name="Heat Energy (E1) high res",
+        icon="mdi:radiator",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    SensorEntityDescription(
         key="63",  # 0x003F
         name="Cooling Energy (E3)",
         icon="mdi:snowflake",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

My Kamstrup 403 meter gives me GJ with two decimals (so 0.01 GJ resolution). I know they can be configured for 3 decimals if your provider is willing. 0.01 GJ is not great resolution - a short shower may not show up at all, and be lumped in with the next one.

This week somebody mentioned to me that there are high resolution registers on some Kamstrups, and he even had the register number for me.

(As you know, Kamstrup is not generous with documentation, but I found a nice table in https://www.nasys.no/wp-content/uploads/Multical_Module_II_data-sheet_IM3100.pdf)

This PR adds the high resolution E1 register, which is in Wh.

label: new-feature

(or enhancement?)

## Breaking change

Not a breaking change to this component, but migrating entities for the energy dashboard is tricky. I don't have documentation ready for that (and I don't think such documentation belongs inside a single component's documentation) but if we can find something good, we should maybe link to it in the changelog?

To be clear, installing this update does not require changing the entity used for the dashboard. The GJ counter will stop working, but I bet people will *want* to change!

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works

I have not added tests. I do have screenshots.

## before

<img width="1688" height="811" alt="Screenshot From 2026-07-09 23-29-28" src="https://github.com/user-attachments/assets/9aab8924-a9c3-40a4-94f9-098782b8c68c" />

## with both sensors configured

You can see the same energy usage being spread out correctly (new) vs. aggregated into one hourly data point (old)

<img width="2514" height="811" alt="Screenshot From 2026-07-10 11-18-02" src="https://github.com/user-attachments/assets/cad1de47-e3df-46d1-86e6-f3fd2f4a3624" />

## after

<img width="2514" height="811" alt="Screenshot From 2026-07-10 15-10-18" src="https://github.com/user-attachments/assets/c5b3ff28-e2d0-4164-8369-59098438c1c9" />
